### PR TITLE
Execute brew tap powerlevel9k before install

### DIFF
--- a/brew/install.sh
+++ b/brew/install.sh
@@ -38,6 +38,7 @@ brew install peco
 brew install pgcli
 brew install postgresql
 # https://github.com/Powerlevel9k/powerlevel9k/wiki/Install-Instructions#macos-with-homebrew
+brew tap sambadevi/powerlevel9k
 brew install powerlevel9k
 
 ### PYTHON ###

--- a/brew/tap.sh
+++ b/brew/tap.sh
@@ -13,8 +13,5 @@ brew tap homebrew/cask-fonts
 # https://devcenter.heroku.com/articles/heroku-cli#download-and-install
 brew tap heroku/brew
 
-# https://github.com/Powerlevel9k/powerlevel9k/wiki/Install-Instructions#macos-with-homebre
-brew tap sambadevi/powerlevel9k
-
 # https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/
 brew tap mongodb/brew


### PR DESCRIPTION
Resolves #67.

Moves `poweverlevel9k`-related `brew tap` before when it's installed. Before, `poweverlevel9k` was attempting to be installed _before_ the `brew tap` executed.